### PR TITLE
Add HandleSvg renderer coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
+    "pretest": "npm run build",
     "test": "node --test tests/*.test.cjs",
     "build": "tsc",
     "render": "npm run sharp:install && ts-node ./src/scripts/renderLocally.ts && npm run sharp:uninstall",

--- a/test_coverage.report
+++ b/test_coverage.report
@@ -1,17 +1,25 @@
 FORMAT_VERSION=1
 REPO=handle-svg
-TIMESTAMP_UTC=2026-02-22T20:07:19Z
+TIMESTAMP_UTC=2026-05-16T06:53:59Z
 THRESHOLD_LINES=90
 THRESHOLD_BRANCHES=90
 TOTAL_LINES_PCT=99.42
-TOTAL_BRANCHES_PCT=92.25
+TOTAL_BRANCHES_PCT=92.10
 STATUS=pass
 SOURCE_PATHS=lib/index.js;lib/utils/{checkContrast.js,constants.js,getMaxOffset.js,imageHelpers.js,index.js,getSocialIcon.js,getFontArrayBuffer.js}
 EXCLUDED_PATHS=src/**:typescript-source-tracked-but-runtime-tests-execute-compiled-lib-output;lib/HandleSvg.js:requires-broader-font-rendering-and-svg-runtime-integration-coverage;lib/scripts/**:local-rendering-scripts-excluded-from-runtime-coverage;lib/interfaces/**:compiled-type-surface-not-runtime-logic
-LANGUAGE_SUMMARY=nodejs:lines=99.42,branches=92.25,tool=c8,status=pass
+LANGUAGE_SUMMARY=nodejs:lines=99.42,branches=92.10,tool=c8,status=pass
 
 === RAW_OUTPUT_STANDARD_NPM_TEST ===
 
+> @koralabs/handle-svg@3.0.15 pretest
+> npm run build
+
+
+> @koralabs/handle-svg@3.0.15 build
+> tsc
+
+
 > @koralabs/handle-svg@3.0.15 test
 > node --test tests/*.test.cjs
 
@@ -19,89 +27,149 @@ TAP version 13
 # Subtest: getFontArrayBuffer returns decompressed array buffer for woff2 resources
 ok 1 - getFontArrayBuffer returns decompressed array buffer for woff2 resources
   ---
-  duration_ms: 1.252473
+  duration_ms: 1.843705
+  type: 'test'
   ...
 # Subtest: getFontArrayBuffer returns original buffer when no decompression is needed
 ok 2 - getFontArrayBuffer returns original buffer when no decompression is needed
   ---
-  duration_ms: 0.152443
+  duration_ms: 0.28964
+  type: 'test'
   ...
-# (node:1150675) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
-# (Use `node --trace-deprecation ...` to show where the warning was created)
-# Subtest: library index exposes default HandleSvg and utility exports
-ok 3 - library index exposes default HandleSvg and utility exports
+# Subtest: HandleSvg builds background, ribbon, border, and contrast-safe logo fragments
+ok 3 - HandleSvg builds background, ribbon, border, and contrast-safe logo fragments
   ---
-  duration_ms: 0.367198
+  duration_ms: 1.663037
+  type: 'test'
+  ...
+# Subtest: HandleSvg builds pfp markup with border, zoom, and bounded offsets
+ok 4 - HandleSvg builds pfp markup with border, zoom, and bounded offsets
+  ---
+  duration_ms: 1.614006
+  type: 'test'
+  ...
+# Subtest: HandleSvg builds QR image fragments for raster and embedded SVG assets
+ok 5 - HandleSvg builds QR image fragments for raster and embedded SVG assets
+  ---
+  duration_ms: 0.922227
+  type: 'test'
+  ...
+# Subtest: HandleSvg derives QR styling options and positioned view properties
+ok 6 - HandleSvg derives QR styling options and positioned view properties
+  ---
+  duration_ms: 0.401017
+  type: 'test'
+  ...
+# Subtest: HandleSvg builds handle-name shadow fallback and validates shadow bounds
+ok 7 - HandleSvg builds handle-name shadow fallback and validates shadow bounds
+  ---
+  duration_ms: 0.756148
+  type: 'test'
+  ...
+# Subtest: HandleSvg builds socials with icon and text fragments
+ok 8 - HandleSvg builds socials with icon and text fragments
+  ---
+  duration_ms: 0.637307
+  type: 'test'
+  ...
+# Subtest: HandleSvg full build composes child fragments and honors disabled dollar sign
+ok 9 - HandleSvg full build composes child fragments and honors disabled dollar sign
+  ---
+  duration_ms: 0.406708
+  type: 'test'
+  ...
+# Subtest: library index exposes default HandleSvg and utility exports
+ok 10 - library index exposes default HandleSvg and utility exports
+  ---
+  duration_ms: 0.781184
+  type: 'test'
   ...
 # Subtest: getSocialIcon resolves known provider branches
-ok 4 - getSocialIcon resolves known provider branches
+ok 11 - getSocialIcon resolves known provider branches
   ---
-  duration_ms: 0.593902
+  duration_ms: 1.24561
+  type: 'test'
   ...
 # Subtest: getSocialIcon falls back to website icon when no provider matches
-ok 5 - getSocialIcon falls back to website icon when no provider matches
+ok 12 - getSocialIcon falls back to website icon when no provider matches
   ---
-  duration_ms: 0.119149
+  duration_ms: 0.146643
+  type: 'test'
   ...
-# (node:1150682) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
-# (Use `node --trace-deprecation ...` to show where the warning was created)
 # Subtest: utils index rarity helpers cover all rarity branches
-ok 6 - utils index rarity helpers cover all rarity branches
+ok 13 - utils index rarity helpers cover all rarity branches
   ---
-  duration_ms: 0.425822
+  duration_ms: 1.275466
+  type: 'test'
   ...
 # Subtest: utils index supports color and font helpers
-ok 7 - utils index supports color and font helpers
+ok 14 - utils index supports color and font helpers
   ---
-  duration_ms: 0.17945
+  duration_ms: 0.323643
+  type: 'test'
   ...
 # Subtest: checkContrast handles default threshold and alpha inputs
-ok 8 - checkContrast handles default threshold and alpha inputs
+ok 15 - checkContrast handles default threshold and alpha inputs
   ---
-  duration_ms: 0.402745
+  duration_ms: 0.775925
+  type: 'test'
   ...
 # Subtest: getMaxOffset handles explicit zoom and fallback zoom
-ok 9 - getMaxOffset handles explicit zoom and fallback zoom
+ok 16 - getMaxOffset handles explicit zoom and fallback zoom
   ---
-  duration_ms: 0.071664
+  duration_ms: 0.167302
+  type: 'test'
   ...
 # Subtest: buildFallbackUrl appends pinata token only for pinata gateway
-ok 10 - buildFallbackUrl appends pinata token only for pinata gateway
+ok 17 - buildFallbackUrl appends pinata token only for pinata gateway
   ---
-  duration_ms: 0.434551
+  duration_ms: 0.621878
+  type: 'test'
   ...
 # Subtest: getImageDetails returns metadata without base64 for direct URLs
-ok 11 - getImageDetails returns metadata without base64 for direct URLs
+ok 18 - getImageDetails returns metadata without base64 for direct URLs
   ---
-  duration_ms: 0.575987
+  duration_ms: 1.098105
+  type: 'test'
   ...
 # Subtest: getImageDetails returns base64 payload for ipfs URLs
-ok 12 - getImageDetails returns base64 payload for ipfs URLs
+ok 19 - getImageDetails returns base64 payload for ipfs URLs
   ---
-  duration_ms: 0.766142
+  duration_ms: 0.548702
+  type: 'test'
   ...
 # Subtest: getImageDetails retries with next gateway on failure
-ok 13 - getImageDetails retries with next gateway on failure
+ok 20 - getImageDetails retries with next gateway on failure
   ---
-  duration_ms: 0.261446
+  duration_ms: 0.372283
+  type: 'test'
   ...
 # Subtest: getImageDetails throws when all gateways fail
-ok 14 - getImageDetails throws when all gateways fail
+ok 21 - getImageDetails throws when all gateways fail
   ---
-  duration_ms: 0.514873
+  duration_ms: 0.765436
+  type: 'test'
   ...
-1..14
-# tests 14
+1..21
+# tests 21
 # suites 0
-# pass 14
+# pass 21
 # fail 0
 # cancelled 0
 # skipped 0
 # todo 0
-# duration_ms 45.448734
+# duration_ms 96.867469
 
 === RAW_OUTPUT_COVERAGE_C8 ===
 
+> @koralabs/handle-svg@3.0.15 pretest
+> npm run build
+
+
+> @koralabs/handle-svg@3.0.15 build
+> tsc
+
+
 > @koralabs/handle-svg@3.0.15 test
 > node --test tests/*.test.cjs
 
@@ -109,98 +177,150 @@ TAP version 13
 # Subtest: getFontArrayBuffer returns decompressed array buffer for woff2 resources
 ok 1 - getFontArrayBuffer returns decompressed array buffer for woff2 resources
   ---
-  duration_ms: 1.061129
+  duration_ms: 2.939636
+  type: 'test'
   ...
 # Subtest: getFontArrayBuffer returns original buffer when no decompression is needed
 ok 2 - getFontArrayBuffer returns original buffer when no decompression is needed
   ---
-  duration_ms: 0.152102
+  duration_ms: 0.348529
+  type: 'test'
   ...
-# (node:1150767) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
-# (Use `node --trace-deprecation ...` to show where the warning was created)
-# Subtest: library index exposes default HandleSvg and utility exports
-ok 3 - library index exposes default HandleSvg and utility exports
+# Subtest: HandleSvg builds background, ribbon, border, and contrast-safe logo fragments
+ok 3 - HandleSvg builds background, ribbon, border, and contrast-safe logo fragments
   ---
-  duration_ms: 0.455914
+  duration_ms: 2.96865
+  type: 'test'
+  ...
+# Subtest: HandleSvg builds pfp markup with border, zoom, and bounded offsets
+ok 4 - HandleSvg builds pfp markup with border, zoom, and bounded offsets
+  ---
+  duration_ms: 0.736241
+  type: 'test'
+  ...
+# Subtest: HandleSvg builds QR image fragments for raster and embedded SVG assets
+ok 5 - HandleSvg builds QR image fragments for raster and embedded SVG assets
+  ---
+  duration_ms: 1.156506
+  type: 'test'
+  ...
+# Subtest: HandleSvg derives QR styling options and positioned view properties
+ok 6 - HandleSvg derives QR styling options and positioned view properties
+  ---
+  duration_ms: 0.39206
+  type: 'test'
+  ...
+# Subtest: HandleSvg builds handle-name shadow fallback and validates shadow bounds
+ok 7 - HandleSvg builds handle-name shadow fallback and validates shadow bounds
+  ---
+  duration_ms: 0.962091
+  type: 'test'
+  ...
+# Subtest: HandleSvg builds socials with icon and text fragments
+ok 8 - HandleSvg builds socials with icon and text fragments
+  ---
+  duration_ms: 0.757521
+  type: 'test'
+  ...
+# Subtest: HandleSvg full build composes child fragments and honors disabled dollar sign
+ok 9 - HandleSvg full build composes child fragments and honors disabled dollar sign
+  ---
+  duration_ms: 0.40784
+  type: 'test'
+  ...
+# Subtest: library index exposes default HandleSvg and utility exports
+ok 10 - library index exposes default HandleSvg and utility exports
+  ---
+  duration_ms: 0.940933
+  type: 'test'
   ...
 # Subtest: getSocialIcon resolves known provider branches
-ok 4 - getSocialIcon resolves known provider branches
+ok 11 - getSocialIcon resolves known provider branches
   ---
-  duration_ms: 0.638591
+  duration_ms: 1.263714
+  type: 'test'
   ...
 # Subtest: getSocialIcon falls back to website icon when no provider matches
-ok 5 - getSocialIcon falls back to website icon when no provider matches
+ok 12 - getSocialIcon falls back to website icon when no provider matches
   ---
-  duration_ms: 0.18725
+  duration_ms: 0.139179
+  type: 'test'
   ...
-# (node:1150774) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
-# (Use `node --trace-deprecation ...` to show where the warning was created)
 # Subtest: utils index rarity helpers cover all rarity branches
-ok 6 - utils index rarity helpers cover all rarity branches
+ok 13 - utils index rarity helpers cover all rarity branches
   ---
-  duration_ms: 0.478518
+  duration_ms: 0.989693
+  type: 'test'
   ...
 # Subtest: utils index supports color and font helpers
-ok 7 - utils index supports color and font helpers
+ok 14 - utils index supports color and font helpers
   ---
-  duration_ms: 0.160367
+  duration_ms: 0.280202
+  type: 'test'
   ...
 # Subtest: checkContrast handles default threshold and alpha inputs
-ok 8 - checkContrast handles default threshold and alpha inputs
+ok 15 - checkContrast handles default threshold and alpha inputs
   ---
-  duration_ms: 0.512946
+  duration_ms: 0.969526
+  type: 'test'
   ...
 # Subtest: getMaxOffset handles explicit zoom and fallback zoom
-ok 9 - getMaxOffset handles explicit zoom and fallback zoom
+ok 16 - getMaxOffset handles explicit zoom and fallback zoom
   ---
-  duration_ms: 0.112064
+  duration_ms: 0.133388
+  type: 'test'
   ...
 # Subtest: buildFallbackUrl appends pinata token only for pinata gateway
-ok 10 - buildFallbackUrl appends pinata token only for pinata gateway
+ok 17 - buildFallbackUrl appends pinata token only for pinata gateway
   ---
-  duration_ms: 0.878632
+  duration_ms: 0.646845
+  type: 'test'
   ...
 # Subtest: getImageDetails returns metadata without base64 for direct URLs
-ok 11 - getImageDetails returns metadata without base64 for direct URLs
+ok 18 - getImageDetails returns metadata without base64 for direct URLs
   ---
-  duration_ms: 0.723671
+  duration_ms: 1.185238
+  type: 'test'
   ...
 # Subtest: getImageDetails returns base64 payload for ipfs URLs
-ok 12 - getImageDetails returns base64 payload for ipfs URLs
+ok 19 - getImageDetails returns base64 payload for ipfs URLs
   ---
-  duration_ms: 0.275139
+  duration_ms: 0.406828
+  type: 'test'
   ...
 # Subtest: getImageDetails retries with next gateway on failure
-ok 13 - getImageDetails retries with next gateway on failure
+ok 20 - getImageDetails retries with next gateway on failure
   ---
-  duration_ms: 0.255946
+  duration_ms: 0.406047
+  type: 'test'
   ...
 # Subtest: getImageDetails throws when all gateways fail
-ok 14 - getImageDetails throws when all gateways fail
+ok 21 - getImageDetails throws when all gateways fail
   ---
-  duration_ms: 0.473157
+  duration_ms: 0.773261
+  type: 'test'
   ...
-1..14
-# tests 14
+1..21
+# tests 21
 # suites 0
-# pass 14
+# pass 21
 # fail 0
 # cancelled 0
 # skipped 0
 # todo 0
-# duration_ms 49.793183
+# duration_ms 118.634855
 ------------------------|---------|----------|---------|---------|-------------------
 File                    | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
 ------------------------|---------|----------|---------|---------|-------------------
-All files               |   99.42 |    92.25 |   90.32 |   99.42 |                   
+All files               |   99.42 |     92.1 |   93.54 |   99.42 |                   
  lib                    |    91.3 |    69.23 |     100 |    91.3 |                   
   index.js              |    91.3 |    69.23 |     100 |    91.3 | 10-11             
- lib/utils              |     100 |    94.57 |   89.28 |     100 |                   
+ lib/utils              |     100 |    94.24 |   92.85 |     100 |                   
   checkContrast.js      |     100 |      100 |     100 |     100 |                   
   constants.js          |     100 |       50 |     100 |     100 | 7                 
-  getFontArrayBuffer.js |     100 |    83.33 |   85.71 |     100 | 3,5,27            
+  getFontArrayBuffer.js |     100 |    83.33 |   85.71 |     100 | 3,5,26            
   getMaxOffset.js       |     100 |      100 |     100 |     100 |                   
   getSocialIcon.js      |     100 |      100 |     100 |     100 |                   
-  imageHelpers.js       |     100 |    88.88 |   88.88 |     100 | 3,12,46           
-  index.js              |     100 |      100 |    87.5 |     100 |                   
+  imageHelpers.js       |     100 |    85.71 |   88.88 |     100 | 3,8,12,46         
+  index.js              |     100 |      100 |     100 |     100 |                   
 ------------------------|---------|----------|---------|---------|-------------------

--- a/tests/handle-svg.test.cjs
+++ b/tests/handle-svg.test.cjs
@@ -1,0 +1,213 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const HandleSvg = require('../lib/HandleSvg.js').default;
+
+const createRenderer = (overrides = {}) =>
+    new HandleSvg({
+        size: overrides.size ?? 1024,
+        handle: overrides.handle ?? 'handle',
+        disableDollarSymbol: overrides.disableDollarSymbol,
+        options: overrides.options ?? {}
+    });
+
+const mockFontResult = (bbox = { x1: 0, y1: -20, x2: 100, y2: 30 }) => ({
+    boundingBox: bbox,
+    parsedFont: {
+        getPath: (text, x, y, fontSize) => ({
+            fill: '',
+            toSVG() {
+                return `<path data-text="${text}" data-x="${x}" data-y="${y}" data-size="${fontSize}" data-fill="${this.fill}" />`;
+            }
+        })
+    }
+});
+
+test('HandleSvg builds background, ribbon, border, and contrast-safe logo fragments', () => {
+    const renderer = createRenderer({
+        size: 2048,
+        handle: 'ada',
+        options: {
+            bg_color: '0xffffff',
+            circuit_color: '0xffffff',
+            font_color: '0xffffff',
+            text_ribbon_colors: ['0xff0000', '0x00ff00', '0x0000ff'],
+            text_ribbon_gradient: 'linear-90',
+            bg_border_color: '0x123456'
+        }
+    });
+
+    assert.equal(renderer.buildBackground(), '<rect width="2048" height="2048" fill="#ffffff" />');
+    assert.equal(renderer.buildDefaultBackground().includes('fill="#FFFFFF1C"'), true);
+
+    const ribbon = renderer.buildTextRibbon();
+    assert.equal(ribbon.includes('linearGradient id="grad1" gradientTransform="rotate(90 0.5 0.5)"'), true);
+    assert.equal(ribbon.includes('offset="50%" stop-color="#00ff00"'), true);
+
+    const border = renderer.buildBackgroundBorder();
+    assert.equal(border.includes('stroke="#123456"'), true);
+    assert.equal(border.includes('stroke-width="30"'), true);
+
+    const logo = renderer.buildLogoHandle();
+    assert.equal(logo.includes('x="80" y="80"'), true);
+    assert.equal(logo.includes('id="handle" fill="#888888"'), true);
+});
+
+test('HandleSvg builds pfp markup with border, zoom, and bounded offsets', () => {
+    const renderer = createRenderer({
+        size: 2048,
+        options: {
+            pfp_image: 'ipfs://pfp',
+            pfp_border_color: '0x112233',
+            pfp_zoom: 150,
+            pfp_offset: [100, -100]
+        }
+    });
+
+    const svg = renderer._buildPfpImageHtmlString('data:image/png;base64,AQID', 1024);
+
+    assert.equal(svg.includes('<clipPath id="circle-path">'), true);
+    assert.equal(svg.includes('fill="#112233"'), true);
+    assert.equal(svg.includes('height="432" width="432"'), true);
+    assert.equal(svg.includes('href="data:image/png;base64,AQID"'), true);
+
+    const invalidRenderer = createRenderer({
+        options: {
+            pfp_image: 'ipfs://pfp',
+            pfp_zoom: 150,
+            pfp_offset: [999, 0]
+        }
+    });
+
+    assert.throws(
+        () => invalidRenderer._buildPfpImageHtmlString('data:image/png;base64,AQID'),
+        /pfp_offset out of bounds/
+    );
+});
+
+test('HandleSvg builds QR image fragments for raster and embedded SVG assets', async () => {
+    const renderer = createRenderer({ size: 1024 });
+
+    const raster = await renderer.buildQrImage('AQID', 'image/png');
+    assert.equal(raster.includes('width="40" height="40"'), true);
+    assert.equal(raster.includes('href="data:image/png;base64,AQID"'), true);
+
+    const encodedSvg = Buffer.from('<svg><rect /></svg>', 'utf8').toString('base64');
+    const svg = await renderer.buildQrImage(
+        encodedSvg,
+        'image/svg+xml',
+        () => JSON.stringify({ svg: { _attributes: {}, rect: {} } }),
+        (obj) => JSON.stringify(obj)
+    );
+    const parsed = JSON.parse(svg);
+
+    assert.deepEqual(parsed.svg._attributes, {
+        width: '40',
+        height: '40',
+        x: '8.16%',
+        y: '8.16%'
+    });
+});
+
+test('HandleSvg derives QR styling options and positioned view properties', () => {
+    const renderer = createRenderer({
+        size: 1024,
+        options: {
+            qr_link: 'https://handle.me/$handle',
+            qr_dot: 'dots,#111111',
+            qr_inner_eye: 'classy,#222222',
+            qr_outer_eye: 'rounded,#333333'
+        }
+    });
+
+    assert.deepEqual(renderer.buildQrCodeOptions(), {
+        width: 215,
+        height: 215,
+        type: 'svg',
+        data: 'https://handle.me/$handle',
+        margin: 0,
+        dotsOptions: { color: '#111111', type: 'dots' },
+        cornersSquareOptions: { color: '#333333', type: 'extra-rounded' },
+        cornersDotOptions: { color: '#222222', type: 'classy' },
+        backgroundOptions: { color: '#FFFFFF00' }
+    });
+
+    assert.deepEqual(renderer.buildQrCodeViewProperties(180), {
+        adjustedQRCodeSize: 200,
+        qrCodeMargin: 15,
+        svgQrPosition: 769,
+        svgViewBox: '17.5 17.5 921.5999999999999 921.5999999999999'
+    });
+});
+
+test('HandleSvg builds handle-name shadow fallback and validates shadow bounds', async () => {
+    const renderer = createRenderer({
+        size: 2048,
+        handle: 'white',
+        options: {
+            bg_color: '0xffffff',
+            font_color: '0xffffff'
+        }
+    });
+    renderer.loadParsedFont = async () => mockFontResult({ x1: 0, y1: -40, x2: 300, y2: 100 });
+
+    const svg = await renderer.buildHandleName(async () => new Uint8Array(), {});
+
+    assert.equal(svg.includes('id="handle_name_white"'), true);
+    assert.equal(svg.includes('filter id="drop-shadow"'), true);
+    assert.equal(svg.includes('flood-color="#888888"'), true);
+    assert.equal(svg.includes('stdDeviation="10"'), true);
+
+    const invalidRenderer = createRenderer({
+        options: {
+            font_shadow_size: [21, 0, 0]
+        }
+    });
+    invalidRenderer.loadParsedFont = async () => mockFontResult();
+
+    await assert.rejects(
+        () => invalidRenderer.buildHandleName(async () => new Uint8Array(), {}),
+        /font shadow horizontal offset must be between -20 and 20/
+    );
+});
+
+test('HandleSvg builds socials with icon and text fragments', async () => {
+    const renderer = createRenderer({
+        size: 2048,
+        options: {
+            socials: [{ url: 'https://twitter.com/handle', display: '@handle' }],
+            font_color: '0x112233'
+        }
+    });
+    renderer.loadParsedFont = async (_font, _decompress, text) =>
+        mockFontResult({ x1: 0, y1: -20, x2: text.length * 20, y2: 44 });
+
+    const svg = await renderer.buildSocialsSvg(async () => new Uint8Array(), {});
+
+    assert.equal(svg.includes('bi-twitter'), true);
+    assert.equal(svg.includes('data-text="@handle"'), true);
+    assert.equal(svg.includes('data-fill="#112233"'), true);
+
+    const emptyRenderer = createRenderer({ options: { socials: [] } });
+    assert.equal(await emptyRenderer.buildSocialsSvg(async () => new Uint8Array(), {}), '');
+});
+
+test('HandleSvg full build composes child fragments and honors disabled dollar sign', async () => {
+    const renderer = createRenderer({ disableDollarSymbol: true });
+    renderer.buildBackgroundImage = async () => '<bg-image />';
+    renderer.buildPfpImage = async () => '<pfp-image />';
+    renderer.buildOG = async () => '<og />';
+    renderer.buildHandleName = async () => '<name />';
+    renderer.buildQRCode = async () => '<qr />';
+    renderer.buildSocialsSvg = async () => '<socials />';
+
+    const svg = await renderer.build(async () => new Uint8Array(), null, null, {});
+
+    assert.equal(svg.includes('<bg-image />'), true);
+    assert.equal(svg.includes('<pfp-image />'), true);
+    assert.equal(svg.includes('<og />'), true);
+    assert.equal(svg.includes('<name />'), true);
+    assert.equal(svg.includes('<qr />'), true);
+    assert.equal(svg.includes('<socials />'), true);
+    assert.equal(svg.includes('M25.02,8.1'), false);
+});


### PR DESCRIPTION
Coverage rotation followed repo-local tooling: package.json test harness, test_coverage.sh c8 diagnostic, workflow config, and stale test_coverage.report. Added focused HandleSvg renderer tests for deterministic background/ribbon/border, contrast, PFP, QR, handle-name, socials, and full-build paths; added pretest build so compiled lib output is fresh for CommonJS tests.

Verify: npm test passed with 21 tests. Diagnostic: ./test_coverage.sh passed. Lesson: coverage-rotation-local-tooling-first.