### PR TITLE
test: cover font array buffer branch cases

### DIFF
--- a/test_coverage.report
+++ b/test_coverage.report
@@ -1,324 +1,348 @@
 FORMAT_VERSION=1
 REPO=handle-svg
-TIMESTAMP_UTC=2026-05-16T06:53:59Z
+TIMESTAMP_UTC=2026-06-01T14:40:36Z
 THRESHOLD_LINES=90
 THRESHOLD_BRANCHES=90
 TOTAL_LINES_PCT=99.42
-TOTAL_BRANCHES_PCT=92.10
+TOTAL_BRANCHES_PCT=92.85
 STATUS=pass
 SOURCE_PATHS=lib/index.js;lib/utils/{checkContrast.js,constants.js,getMaxOffset.js,imageHelpers.js,index.js,getSocialIcon.js,getFontArrayBuffer.js}
 EXCLUDED_PATHS=src/**:typescript-source-tracked-but-runtime-tests-execute-compiled-lib-output;lib/HandleSvg.js:requires-broader-font-rendering-and-svg-runtime-integration-coverage;lib/scripts/**:local-rendering-scripts-excluded-from-runtime-coverage;lib/interfaces/**:compiled-type-surface-not-runtime-logic
-LANGUAGE_SUMMARY=nodejs:lines=99.42,branches=92.10,tool=c8,status=pass
+LANGUAGE_SUMMARY=nodejs:lines=99.42,branches=92.85,tool=c8,status=pass
 
 === RAW_OUTPUT_STANDARD_NPM_TEST ===
 
-> @koralabs/handle-svg@3.0.15 pretest
+> @koralabs/handle-svg@3.0.16 pretest
 > npm run build
 
 
-> @koralabs/handle-svg@3.0.15 build
+> @koralabs/handle-svg@3.0.16 build
 > tsc
 
 
-> @koralabs/handle-svg@3.0.15 test
+> @koralabs/handle-svg@3.0.16 test
 > node --test tests/*.test.cjs
 
 TAP version 13
 # Subtest: getFontArrayBuffer returns decompressed array buffer for woff2 resources
 ok 1 - getFontArrayBuffer returns decompressed array buffer for woff2 resources
   ---
-  duration_ms: 1.843705
+  duration_ms: 2.683728
+  type: 'test'
+  ...
+# Subtest: getFontArrayBuffer decompresses woff2 URLs even when content type is generic
+ok 2 - getFontArrayBuffer decompresses woff2 URLs even when content type is generic
+  ---
+  duration_ms: 0.361303
   type: 'test'
   ...
 # Subtest: getFontArrayBuffer returns original buffer when no decompression is needed
-ok 2 - getFontArrayBuffer returns original buffer when no decompression is needed
+ok 3 - getFontArrayBuffer returns original buffer when no decompression is needed
   ---
-  duration_ms: 0.28964
+  duration_ms: 0.362495
+  type: 'test'
+  ...
+# Subtest: getFontArrayBuffer returns original buffer when content type is missing
+ok 4 - getFontArrayBuffer returns original buffer when content type is missing
+  ---
+  duration_ms: 0.275093
   type: 'test'
   ...
 # Subtest: HandleSvg builds background, ribbon, border, and contrast-safe logo fragments
-ok 3 - HandleSvg builds background, ribbon, border, and contrast-safe logo fragments
+ok 5 - HandleSvg builds background, ribbon, border, and contrast-safe logo fragments
   ---
-  duration_ms: 1.663037
+  duration_ms: 1.452636
   type: 'test'
   ...
 # Subtest: HandleSvg builds pfp markup with border, zoom, and bounded offsets
-ok 4 - HandleSvg builds pfp markup with border, zoom, and bounded offsets
+ok 6 - HandleSvg builds pfp markup with border, zoom, and bounded offsets
   ---
-  duration_ms: 1.614006
+  duration_ms: 0.628952
   type: 'test'
   ...
 # Subtest: HandleSvg builds QR image fragments for raster and embedded SVG assets
-ok 5 - HandleSvg builds QR image fragments for raster and embedded SVG assets
+ok 7 - HandleSvg builds QR image fragments for raster and embedded SVG assets
   ---
-  duration_ms: 0.922227
+  duration_ms: 0.983622
   type: 'test'
   ...
 # Subtest: HandleSvg derives QR styling options and positioned view properties
-ok 6 - HandleSvg derives QR styling options and positioned view properties
+ok 8 - HandleSvg derives QR styling options and positioned view properties
   ---
-  duration_ms: 0.401017
+  duration_ms: 2.074645
   type: 'test'
   ...
 # Subtest: HandleSvg builds handle-name shadow fallback and validates shadow bounds
-ok 7 - HandleSvg builds handle-name shadow fallback and validates shadow bounds
+ok 9 - HandleSvg builds handle-name shadow fallback and validates shadow bounds
   ---
-  duration_ms: 0.756148
+  duration_ms: 0.814035
   type: 'test'
   ...
 # Subtest: HandleSvg builds socials with icon and text fragments
-ok 8 - HandleSvg builds socials with icon and text fragments
+ok 10 - HandleSvg builds socials with icon and text fragments
   ---
-  duration_ms: 0.637307
+  duration_ms: 0.66048
   type: 'test'
   ...
 # Subtest: HandleSvg full build composes child fragments and honors disabled dollar sign
-ok 9 - HandleSvg full build composes child fragments and honors disabled dollar sign
+ok 11 - HandleSvg full build composes child fragments and honors disabled dollar sign
   ---
-  duration_ms: 0.406708
+  duration_ms: 0.422227
   type: 'test'
   ...
 # Subtest: library index exposes default HandleSvg and utility exports
-ok 10 - library index exposes default HandleSvg and utility exports
+ok 12 - library index exposes default HandleSvg and utility exports
   ---
-  duration_ms: 0.781184
+  duration_ms: 0.749416
   type: 'test'
   ...
 # Subtest: getSocialIcon resolves known provider branches
-ok 11 - getSocialIcon resolves known provider branches
+ok 13 - getSocialIcon resolves known provider branches
   ---
-  duration_ms: 1.24561
+  duration_ms: 1.224231
   type: 'test'
   ...
 # Subtest: getSocialIcon falls back to website icon when no provider matches
-ok 12 - getSocialIcon falls back to website icon when no provider matches
+ok 14 - getSocialIcon falls back to website icon when no provider matches
   ---
-  duration_ms: 0.146643
+  duration_ms: 0.149047
   type: 'test'
   ...
 # Subtest: utils index rarity helpers cover all rarity branches
-ok 13 - utils index rarity helpers cover all rarity branches
+ok 15 - utils index rarity helpers cover all rarity branches
   ---
-  duration_ms: 1.275466
+  duration_ms: 0.838902
   type: 'test'
   ...
 # Subtest: utils index supports color and font helpers
-ok 14 - utils index supports color and font helpers
+ok 16 - utils index supports color and font helpers
   ---
-  duration_ms: 0.323643
+  duration_ms: 0.324384
   type: 'test'
   ...
 # Subtest: checkContrast handles default threshold and alpha inputs
-ok 15 - checkContrast handles default threshold and alpha inputs
+ok 17 - checkContrast handles default threshold and alpha inputs
   ---
-  duration_ms: 0.775925
+  duration_ms: 0.706557
   type: 'test'
   ...
 # Subtest: getMaxOffset handles explicit zoom and fallback zoom
-ok 16 - getMaxOffset handles explicit zoom and fallback zoom
+ok 18 - getMaxOffset handles explicit zoom and fallback zoom
   ---
-  duration_ms: 0.167302
+  duration_ms: 0.166781
   type: 'test'
   ...
 # Subtest: buildFallbackUrl appends pinata token only for pinata gateway
-ok 17 - buildFallbackUrl appends pinata token only for pinata gateway
+ok 19 - buildFallbackUrl appends pinata token only for pinata gateway
   ---
-  duration_ms: 0.621878
+  duration_ms: 0.574971
   type: 'test'
   ...
 # Subtest: getImageDetails returns metadata without base64 for direct URLs
-ok 18 - getImageDetails returns metadata without base64 for direct URLs
+ok 20 - getImageDetails returns metadata without base64 for direct URLs
   ---
-  duration_ms: 1.098105
+  duration_ms: 0.960579
   type: 'test'
   ...
 # Subtest: getImageDetails returns base64 payload for ipfs URLs
-ok 19 - getImageDetails returns base64 payload for ipfs URLs
+ok 21 - getImageDetails returns base64 payload for ipfs URLs
   ---
-  duration_ms: 0.548702
+  duration_ms: 0.523406
   type: 'test'
   ...
 # Subtest: getImageDetails retries with next gateway on failure
-ok 20 - getImageDetails retries with next gateway on failure
+ok 22 - getImageDetails retries with next gateway on failure
   ---
-  duration_ms: 0.372283
+  duration_ms: 0.369057
   type: 'test'
   ...
 # Subtest: getImageDetails throws when all gateways fail
-ok 21 - getImageDetails throws when all gateways fail
+ok 23 - getImageDetails throws when all gateways fail
   ---
-  duration_ms: 0.765436
+  duration_ms: 0.743094
   type: 'test'
   ...
-1..21
-# tests 21
+1..23
+# tests 23
 # suites 0
-# pass 21
+# pass 23
 # fail 0
 # cancelled 0
 # skipped 0
 # todo 0
-# duration_ms 96.867469
+# duration_ms 102.275638
 
 === RAW_OUTPUT_COVERAGE_C8 ===
 
-> @koralabs/handle-svg@3.0.15 pretest
+> @koralabs/handle-svg@3.0.16 pretest
 > npm run build
 
 
-> @koralabs/handle-svg@3.0.15 build
+> @koralabs/handle-svg@3.0.16 build
 > tsc
 
 
-> @koralabs/handle-svg@3.0.15 test
+> @koralabs/handle-svg@3.0.16 test
 > node --test tests/*.test.cjs
 
 TAP version 13
 # Subtest: getFontArrayBuffer returns decompressed array buffer for woff2 resources
 ok 1 - getFontArrayBuffer returns decompressed array buffer for woff2 resources
   ---
-  duration_ms: 2.939636
+  duration_ms: 2.465743
+  type: 'test'
+  ...
+# Subtest: getFontArrayBuffer decompresses woff2 URLs even when content type is generic
+ok 2 - getFontArrayBuffer decompresses woff2 URLs even when content type is generic
+  ---
+  duration_ms: 0.386489
   type: 'test'
   ...
 # Subtest: getFontArrayBuffer returns original buffer when no decompression is needed
-ok 2 - getFontArrayBuffer returns original buffer when no decompression is needed
+ok 3 - getFontArrayBuffer returns original buffer when no decompression is needed
   ---
-  duration_ms: 0.348529
+  duration_ms: 0.325125
+  type: 'test'
+  ...
+# Subtest: getFontArrayBuffer returns original buffer when content type is missing
+ok 4 - getFontArrayBuffer returns original buffer when content type is missing
+  ---
+  duration_ms: 1.309829
   type: 'test'
   ...
 # Subtest: HandleSvg builds background, ribbon, border, and contrast-safe logo fragments
-ok 3 - HandleSvg builds background, ribbon, border, and contrast-safe logo fragments
+ok 5 - HandleSvg builds background, ribbon, border, and contrast-safe logo fragments
   ---
-  duration_ms: 2.96865
+  duration_ms: 3.311468
   type: 'test'
   ...
 # Subtest: HandleSvg builds pfp markup with border, zoom, and bounded offsets
-ok 4 - HandleSvg builds pfp markup with border, zoom, and bounded offsets
+ok 6 - HandleSvg builds pfp markup with border, zoom, and bounded offsets
   ---
-  duration_ms: 0.736241
+  duration_ms: 0.913792
   type: 'test'
   ...
 # Subtest: HandleSvg builds QR image fragments for raster and embedded SVG assets
-ok 5 - HandleSvg builds QR image fragments for raster and embedded SVG assets
+ok 7 - HandleSvg builds QR image fragments for raster and embedded SVG assets
   ---
-  duration_ms: 1.156506
+  duration_ms: 1.269635
   type: 'test'
   ...
 # Subtest: HandleSvg derives QR styling options and positioned view properties
-ok 6 - HandleSvg derives QR styling options and positioned view properties
+ok 8 - HandleSvg derives QR styling options and positioned view properties
   ---
-  duration_ms: 0.39206
+  duration_ms: 0.414704
   type: 'test'
   ...
 # Subtest: HandleSvg builds handle-name shadow fallback and validates shadow bounds
-ok 7 - HandleSvg builds handle-name shadow fallback and validates shadow bounds
+ok 9 - HandleSvg builds handle-name shadow fallback and validates shadow bounds
   ---
-  duration_ms: 0.962091
+  duration_ms: 0.962773
   type: 'test'
   ...
 # Subtest: HandleSvg builds socials with icon and text fragments
-ok 8 - HandleSvg builds socials with icon and text fragments
+ok 10 - HandleSvg builds socials with icon and text fragments
   ---
-  duration_ms: 0.757521
+  duration_ms: 0.745899
   type: 'test'
   ...
 # Subtest: HandleSvg full build composes child fragments and honors disabled dollar sign
-ok 9 - HandleSvg full build composes child fragments and honors disabled dollar sign
+ok 11 - HandleSvg full build composes child fragments and honors disabled dollar sign
   ---
-  duration_ms: 0.40784
+  duration_ms: 0.433056
   type: 'test'
   ...
 # Subtest: library index exposes default HandleSvg and utility exports
-ok 10 - library index exposes default HandleSvg and utility exports
+ok 12 - library index exposes default HandleSvg and utility exports
   ---
-  duration_ms: 0.940933
+  duration_ms: 0.946844
   type: 'test'
   ...
 # Subtest: getSocialIcon resolves known provider branches
-ok 11 - getSocialIcon resolves known provider branches
+ok 13 - getSocialIcon resolves known provider branches
   ---
-  duration_ms: 1.263714
+  duration_ms: 1.358881
   type: 'test'
   ...
 # Subtest: getSocialIcon falls back to website icon when no provider matches
-ok 12 - getSocialIcon falls back to website icon when no provider matches
+ok 14 - getSocialIcon falls back to website icon when no provider matches
   ---
-  duration_ms: 0.139179
+  duration_ms: 0.205313
   type: 'test'
   ...
 # Subtest: utils index rarity helpers cover all rarity branches
-ok 13 - utils index rarity helpers cover all rarity branches
+ok 15 - utils index rarity helpers cover all rarity branches
   ---
-  duration_ms: 0.989693
+  duration_ms: 1.012214
   type: 'test'
   ...
 # Subtest: utils index supports color and font helpers
-ok 14 - utils index supports color and font helpers
+ok 16 - utils index supports color and font helpers
   ---
-  duration_ms: 0.280202
+  duration_ms: 0.286293
   type: 'test'
   ...
 # Subtest: checkContrast handles default threshold and alpha inputs
-ok 15 - checkContrast handles default threshold and alpha inputs
+ok 17 - checkContrast handles default threshold and alpha inputs
   ---
-  duration_ms: 0.969526
+  duration_ms: 1.183795
   type: 'test'
   ...
 # Subtest: getMaxOffset handles explicit zoom and fallback zoom
-ok 16 - getMaxOffset handles explicit zoom and fallback zoom
+ok 18 - getMaxOffset handles explicit zoom and fallback zoom
   ---
-  duration_ms: 0.133388
+  duration_ms: 0.15071
   type: 'test'
   ...
 # Subtest: buildFallbackUrl appends pinata token only for pinata gateway
-ok 17 - buildFallbackUrl appends pinata token only for pinata gateway
+ok 19 - buildFallbackUrl appends pinata token only for pinata gateway
   ---
-  duration_ms: 0.646845
+  duration_ms: 0.652846
   type: 'test'
   ...
 # Subtest: getImageDetails returns metadata without base64 for direct URLs
-ok 18 - getImageDetails returns metadata without base64 for direct URLs
+ok 20 - getImageDetails returns metadata without base64 for direct URLs
   ---
-  duration_ms: 1.185238
+  duration_ms: 1.215384
   type: 'test'
   ...
 # Subtest: getImageDetails returns base64 payload for ipfs URLs
-ok 19 - getImageDetails returns base64 payload for ipfs URLs
+ok 21 - getImageDetails returns base64 payload for ipfs URLs
   ---
-  duration_ms: 0.406828
+  duration_ms: 0.416595
   type: 'test'
   ...
 # Subtest: getImageDetails retries with next gateway on failure
-ok 20 - getImageDetails retries with next gateway on failure
+ok 22 - getImageDetails retries with next gateway on failure
   ---
-  duration_ms: 0.406047
+  duration_ms: 0.387561
   type: 'test'
   ...
 # Subtest: getImageDetails throws when all gateways fail
-ok 21 - getImageDetails throws when all gateways fail
+ok 23 - getImageDetails throws when all gateways fail
   ---
-  duration_ms: 0.773261
+  duration_ms: 0.772759
   type: 'test'
   ...
-1..21
-# tests 21
+1..23
+# tests 23
 # suites 0
-# pass 21
+# pass 23
 # fail 0
 # cancelled 0
 # skipped 0
 # todo 0
-# duration_ms 118.634855
+# duration_ms 129.873789
 ------------------------|---------|----------|---------|---------|-------------------
 File                    | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
 ------------------------|---------|----------|---------|---------|-------------------
-All files               |   99.42 |     92.1 |   93.54 |   99.42 |                   
+All files               |   99.42 |    92.85 |   93.54 |   99.42 |                   
  lib                    |    91.3 |    69.23 |     100 |    91.3 |                   
   index.js              |    91.3 |    69.23 |     100 |    91.3 | 10-11             
- lib/utils              |     100 |    94.24 |   92.85 |     100 |                   
+ lib/utils              |     100 |    95.03 |   92.85 |     100 |                   
   checkContrast.js      |     100 |      100 |     100 |     100 |                   
   constants.js          |     100 |       50 |     100 |     100 | 7                 
-  getFontArrayBuffer.js |     100 |    83.33 |   85.71 |     100 | 3,5,26            
+  getFontArrayBuffer.js |     100 |       90 |   85.71 |     100 | 3,5               
   getMaxOffset.js       |     100 |      100 |     100 |     100 |                   
   getSocialIcon.js      |     100 |      100 |     100 |     100 |                   
   imageHelpers.js       |     100 |    85.71 |   88.88 |     100 | 3,8,12,46         

--- a/tests/getFontArrayBuffer.test.cjs
+++ b/tests/getFontArrayBuffer.test.cjs
@@ -33,6 +33,23 @@ test('getFontArrayBuffer returns decompressed array buffer for woff2 resources',
     });
 });
 
+test('getFontArrayBuffer decompresses woff2 URLs even when content type is generic', async () => {
+    let decompressCalls = 0;
+
+    await withFetch(async () => ({
+        headers: { get: () => 'application/octet-stream' },
+        arrayBuffer: async () => Uint8Array.from([1, 2, 3]).buffer
+    }), async () => {
+        const result = await getFontArrayBuffer('https://example.com/font.woff2', async () => {
+            decompressCalls += 1;
+            return Uint8Array.from([4, 5, 6]);
+        });
+
+        assert.equal(decompressCalls, 1);
+        assert.deepEqual(Array.from(new Uint8Array(result)), [4, 5, 6]);
+    });
+});
+
 test('getFontArrayBuffer returns original buffer when no decompression is needed', async () => {
     await withFetch(async () => ({
         headers: { get: () => 'font/ttf' },
@@ -43,5 +60,18 @@ test('getFontArrayBuffer returns original buffer when no decompression is needed
         });
 
         assert.deepEqual(Array.from(new Uint8Array(result)), [5, 4, 3]);
+    });
+});
+
+test('getFontArrayBuffer returns original buffer when content type is missing', async () => {
+    await withFetch(async () => ({
+        headers: { get: () => null },
+        arrayBuffer: async () => Uint8Array.from([6, 7, 8]).buffer
+    }), async () => {
+        const result = await getFontArrayBuffer('https://example.com/font.bin', async () => {
+            throw new Error('decompress should not run');
+        });
+
+        assert.deepEqual(Array.from(new Uint8Array(result)), [6, 7, 8]);
     });
 });


### PR DESCRIPTION
Coverage sweep added focused getFontArrayBuffer branch tests for generic content-type .woff2 decompression and missing content-type non-woff2 passthrough. Verify passed: npm test passed with 23 tests, and bash test_coverage.sh passed with line coverage 99.42% and branch coverage 92.85%. Synthesis lesson staged as 1780324915068-01ebcf42.