### PR TITLE
fix: subhandle rarity color matches root handle (handle.me#872)

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,8 +8,18 @@ export const getRarityFromLength = (length: number): string => {
     return 'Basic';
 };
 
+/**
+ * The segment a handle's rarity is derived from: the root handle for a subhandle
+ * (`sub@root` -> `root`), otherwise the handle itself. A subhandle inherits its
+ * root handle's rarity color (handle.me#872). Note: rarity COLOR uses this root
+ * segment, but text sizing (getMinimumFontSize) deliberately keeps the full
+ * displayed handle length.
+ */
+export const getRarityHandleSegment = (handle: string): string =>
+    handle.includes('@') ? handle.split('@').pop() ?? handle : handle;
+
 export const getRarityHex = (handle: string): string => {
-    const rarity = getRarityFromLength(handle.length);
+    const rarity = getRarityFromLength(getRarityHandleSegment(handle).length);
     switch (rarity) {
         case 'Legendary':
             return '#f4900c';

--- a/tests/rarity-subhandle.test.cjs
+++ b/tests/rarity-subhandle.test.cjs
@@ -1,0 +1,22 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { getRarityHex, getRarityHandleSegment } = require('../lib/utils/index.js');
+
+test('getRarityHandleSegment returns the root for a subhandle, the handle otherwise', () => {
+    assert.equal(getRarityHandleSegment('sub@root'), 'root');
+    assert.equal(getRarityHandleSegment('root'), 'root');
+});
+
+test('subhandle rarity color matches its root handle, not the combined length (handle.me#872)', () => {
+    // 'a' is a 1-char Legendary root.
+    assert.equal(getRarityHex('sub@a'), getRarityHex('a'));
+    assert.equal(getRarityHex('sub@a'), '#f4900c'); // Legendary
+    // 'subxa' (no @) is 5 chars -> Common; the subhandle must NOT pick that up.
+    assert.notEqual(getRarityHex('sub@a'), getRarityHex('subxa'));
+});
+
+test('root-handle rarity is unchanged', () => {
+    assert.equal(getRarityHex('ab'), '#593292'); // 2-char Ultra Rare
+    assert.equal(getRarityHex('abcd'), '#0cd15b'); // 4-char Common
+});


### PR DESCRIPTION
Addresses koralabs/handle.me#872.

## Problem
`getRarityHex` derives rarity from `handle.length`. For a subhandle rendered as `sub@root`, that uses the **combined-string length**, so the dollar-marker rarity color diverged from the root handle's rarity.

## Fix
`getRarityHex` now derives rarity from the **root segment** via a new exported `getRarityHandleSegment` (`sub@root` → `root`; non-subhandles unchanged). Only the rarity **color** uses the root — `getMinimumFontSize` deliberately keeps the full displayed handle length for text sizing (the long `sub@root` still needs to fit).

## Tests
- subhandle color `==` its root color, and `!=` the combined-length color; root-handle colors unchanged. **24/24**, eslint clean.

## Follow-up
handle.me consumes `@koralabs/handle-svg@3.0.13`. A version bump to the release carrying this fix closes handle.me#872 end-to-end (and lets handle.me reuse `getRarityHandleSegment` for its own rarity text labels, e.g. `Search/Mint`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)